### PR TITLE
return raw location object as well in WFS response

### DIFF
--- a/build_src/config/devices.json
+++ b/build_src/config/devices.json
@@ -112,6 +112,15 @@
       }
     },
     {
+      "localName": "location_object",
+      "type": {
+        "binding": "java.lang.String"
+      },
+      "userData": {
+        "mapping": "location"
+      }
+    },
+    {
       "localName": "sensors",
       "minOccurs": 0,
       "maxOccurs": 1,


### PR DESCRIPTION
GeoServer reads the `location` property in MongoDB as a Geometry, converting the coordinate to a (x, y) Point. The height is discarded, it won't show up in the WFS response and won't be shown on the map.

To solve this, the raw location object itself is included in the WFS response too. The central viewer can then parse this (stringified) object and get the location from there.