### PR TITLE
feat: add options to disable web interface

### DIFF
--- a/build_src/scripts/entrypoint.sh
+++ b/build_src/scripts/entrypoint.sh
@@ -14,6 +14,9 @@ export GEOSERVER_OPTS="-Djava.awt.headless=true -server -Xms${INITIAL_MEMORY} -X
 
     #    -Dlog4j.configuration=file:///${GEOSERVER_DATA_DIR}/log4j.xml \
 
+CONSOLE_DISABLED="${geoserver_console_disabled:-false}"
+export GEOSERVER_OPTS="${GEOSERVER_OPTS} -DGEOSERVER_CONSOLE_DISABLED=${CONSOLE_DISABLED}"
+
 ## Preparare the JVM command line arguments
 export JAVA_OPTS="${JAVA_OPTS} ${GEOSERVER_OPTS}"
 


### PR DESCRIPTION
Added environment variable `geoserver_console_disabled`, which can be used to disable the admin interface. If it is not set, assume development environment, setting it to `false`. Default is `true` in Helm Charts.

Closes https://github.com/kadaster-labs/sensrnet-central-viewer-geoserver/issues/11